### PR TITLE
Fix threading issues with ZIP archives

### DIFF
--- a/cli/src/main/java/net/neoforged/jst/cli/SourceFileProcessor.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/SourceFileProcessor.java
@@ -45,7 +45,7 @@ class SourceFileProcessor implements AutoCloseable {
             transformer.beforeRun(context);
         }
 
-        if (sink.isOrdered()) {
+        if (source.isOrdered() && sink.isOrdered()) {
             try (var stream = source.streamEntries()) {
                 stream.forEach(entry -> {
                     try {
@@ -82,7 +82,8 @@ class SourceFileProcessor implements AutoCloseable {
         try (var in = entry.openInputStream()) {
             byte[] content = in.readAllBytes();
             var lastModified = entry.lastModified();
-            if (entry.hasExtension("java")) {
+
+            if (!transformers.isEmpty() && entry.hasExtension("java")) {
                 var orgContent = content;
                 content = transformSource(sourceRoot, entry.relativePath(), transformers, content);
                 if (orgContent != content) {

--- a/cli/src/main/java/net/neoforged/jst/cli/io/ArchiveFileSource.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/io/ArchiveFileSource.java
@@ -9,7 +9,10 @@ import net.neoforged.jst.api.FileSource;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import java.util.zip.ZipFile;
 
 class ArchiveFileSource implements FileSource {
@@ -28,7 +31,13 @@ class ArchiveFileSource implements FileSource {
 
     @Override
     public Stream<FileEntry> streamEntries() {
-        return zipFile.stream().map(ze -> FileEntries.ofZipEntry(zipFile, ze));
+        var spliterator = Spliterators.spliterator(
+                zipFile.entries().asIterator(),
+                zipFile.size(),
+                Spliterator.IMMUTABLE | Spliterator.ORDERED
+        );
+        return StreamSupport.stream(spliterator, false)
+                .map(ze -> FileEntries.ofZipEntry(zipFile, ze));
     }
 
     @Override

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -223,6 +223,7 @@ public class EmbeddedTest {
         Files.write(librariesFile, List.of("-e=" + junitJarPath));
 
         runTool(
+                "--max-queue-depth=1",
                 "--libraries-list",
                 librariesFile.toString(),
                 "--enable-parchment",


### PR DESCRIPTION
Turns out that ZipFile#stream() locks the ZipFile while the stream is being iterated upon. Presumably since it expects that the ZipFile could be written to.
Since we use it read-only, we can avoid that, but now have to write our own Spliterator over the Iterator, which doesn't lock the ZipFile.

`ZipFile#getInputStream` seems to be implemented in a thread-safe manner and reads on the underlying ZipFile are synchronized (which is *not* ideal, but doesn't crash either).