### PR TITLE
Do not rename parameters for record constructors

### DIFF
--- a/api/src/main/java/net/neoforged/jst/api/PsiHelper.java
+++ b/api/src/main/java/net/neoforged/jst/api/PsiHelper.java
@@ -137,4 +137,9 @@ public final class PsiHelper {
             return -1;
         }
     }
+
+    public static boolean isRecordConstructor(PsiMethod psiMethod) {
+        var containingClass = psiMethod.getContainingClass();
+        return containingClass != null && containingClass.isRecord() && psiMethod.isConstructor();
+    }
 }

--- a/parchment/src/main/java/net/neoforged/jst/parchment/GatherReplacementsVisitor.java
+++ b/parchment/src/main/java/net/neoforged/jst/parchment/GatherReplacementsVisitor.java
@@ -93,8 +93,9 @@ class GatherReplacementsVisitor extends PsiRecursiveElementVisitor {
                     var jvmIndex = PsiHelper.getBinaryIndex(psiParameter, i);
 
                     var paramData = methodData.getParameter(jvmIndex);
-                    // Optionally replace the parameter name
-                    if (paramData != null && paramData.getName() != null) {
+                    // Optionally replace the parameter name, but skip record constructors, since those could have
+                    // implications for the field names.
+                    if (paramData != null && paramData.getName() != null && !PsiHelper.isRecordConstructor(psiMethod)) {
                         // Replace parameters within the method body
                         activeParameters.put(psiParameter, paramData);
 


### PR DESCRIPTION
Parchment data also contains parameter names for Record constructors. For the normal parameter set this doesn't matter, but the `checked` version that we use (with all parameters prefixed by `p`), breaks recompilation since Record constructor parameters should not be renamed.

This introduces a workaround that explicitly skips parameter renaming for record constructor parameters.