### PR TITLE
Add the option to add path-prefixes that should not be transformed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Usage: jst [-hV] [--in-format=<inputFormat>] [--libraries-list=<librariesList>]
                            Additional classpath entries to use. Is combined with --libraries-list.
   -h, --help               Show this help message and exit.
       --ignore-prefix=<ignoredPrefixes>
-                           Do not transforms entry whose path start with this prefix.
+                           Do not apply transformations to paths that start with any of these
+                             prefixes.
       --in-format=<inputFormat>
                            Specify the format of INPUT explicitly. AUTO (the default) performs
                              auto-detection. Other options are SINGLE_FILE for Java files, ARCHIVE

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ It can be invoked as a standalone executable Jar-File. Java 17 is required.
 ```
 Usage: jst [-hV] [--in-format=<inputFormat>] [--libraries-list=<librariesList>]
            [--max-queue-depth=<maxQueueDepth>] [--out-format=<outputFormat>]
-           [--classpath=<addToClasspath>]... [--enable-parchment
-           --parchment-mappings=<mappingsPath> [--[no-]parchment-javadoc]
+           [--classpath=<addToClasspath>]... [--ignore-prefix=<ignoredPrefixes>]...
+           [--enable-parchment --parchment-mappings=<mappingsPath> [--[no-]parchment-javadoc]
            [--parchment-conflict-prefix=<conflictPrefix>]] [--enable-accesstransformers
            --access-transformer=<atFiles> [--access-transformer=<atFiles>]...
            [--access-transformer-validation=<validation>]] INPUT OUTPUT
@@ -40,6 +40,8 @@ Usage: jst [-hV] [--in-format=<inputFormat>] [--libraries-list=<librariesList>]
       --classpath=<addToClasspath>
                            Additional classpath entries to use. Is combined with --libraries-list.
   -h, --help               Show this help message and exit.
+      --ignore-prefix=<ignoredPrefixes>
+                           Do not transforms entry whose path start with this prefix.
       --in-format=<inputFormat>
                            Specify the format of INPUT explicitly. AUTO (the default) performs
                              auto-detection. Other options are SINGLE_FILE for Java files, ARCHIVE

--- a/cli/src/main/java/net/neoforged/jst/cli/Main.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/Main.java
@@ -32,7 +32,7 @@ public class Main implements Callable<Integer> {
     @CommandLine.Option(names = "--libraries-list", description = "Specifies a file that contains a path to an archive or directory to add to the classpath on each line.")
     Path librariesList;
 
-    @CommandLine.Option(names = "--ignore-prefix", description = "Do not transforms entry whose path start with this prefix.")
+    @CommandLine.Option(names = "--ignore-prefix", description = "Do not apply transformations to paths that start with any of these prefixes.")
     List<String> ignoredPrefixes = new ArrayList<>();
 
     @CommandLine.Option(names = "--classpath", description = "Additional classpath entries to use. Is combined with --libraries-list.", converter = ClasspathConverter.class)

--- a/cli/src/main/java/net/neoforged/jst/cli/Main.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/Main.java
@@ -32,6 +32,9 @@ public class Main implements Callable<Integer> {
     @CommandLine.Option(names = "--libraries-list", description = "Specifies a file that contains a path to an archive or directory to add to the classpath on each line.")
     Path librariesList;
 
+    @CommandLine.Option(names = "--ignore-prefix", description = "Do not transforms entry whose path start with this prefix.")
+    List<String> ignoredPrefixes = new ArrayList<>();
+
     @CommandLine.Option(names = "--classpath", description = "Additional classpath entries to use. Is combined with --libraries-list.", converter = ClasspathConverter.class)
     List<Path> addToClasspath = new ArrayList<>();
 
@@ -72,6 +75,9 @@ public class Main implements Callable<Integer> {
             }
             for (Path path : addToClasspath) {
                 processor.addLibrary(path);
+            }
+            for (String ignoredPrefix : ignoredPrefixes) {
+                processor.addIgnoredPrefix(ignoredPrefix);
             }
 
             processor.setMaxQueueDepth(maxQueueDepth);

--- a/parchment/src/main/java/net/neoforged/jst/parchment/GatherReplacementsVisitor.java
+++ b/parchment/src/main/java/net/neoforged/jst/parchment/GatherReplacementsVisitor.java
@@ -61,8 +61,9 @@ class GatherReplacementsVisitor extends PsiRecursiveElementVisitor {
                 if (foundClass == null) {
                     throw new IllegalStateException("Failed to find how class " + psiClass.getQualifiedName() + " was loaded while processing it");
                 } else if (foundClass != psiClass) {
-                    throw new IllegalStateException("Class " + psiClass + " was loaded from two different sources: " +
-                            psiClass.getContainingFile() + " and " + foundClass.getContainingFile());
+                    throw new IllegalStateException("Class " + psiClass.getQualifiedName() + " was loaded from two different sources: " +
+                                                    psiClass.getContainingFile().getVirtualFile().getPath() + " and " +
+                                                    foundClass.getContainingFile().getVirtualFile().getPath());
                 }
             }
 


### PR DESCRIPTION
Adds the ability to ignore source-elements via path-prefixes.

Allows us to ignore `mcp/` since that may be present in both the classpath and input files.