### PR TITLE
Fix published dependencies

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -60,12 +60,12 @@ components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElemen
 
 abstract class ComponentMaker {
     @Inject
-    abstract SoftwareComponentFactory getFactory();
+    abstract SoftwareComponentFactory getFactory()
 }
 
-def componentFactory = objects.newInstance(ComponentMaker).factory
+final componentFactory = objects.newInstance(ComponentMaker).factory
 
-def shadowComponent = componentFactory.adhoc("shadow")
+final shadowComponent = componentFactory.adhoc("shadow")
 project.components.add(shadowComponent)
 
 tasks.named('shadowJar', Jar) {
@@ -76,8 +76,6 @@ tasks.named('shadowJar', Jar) {
 shadowComponent.addVariantsFromConfiguration(configurations.shadowRuntimeElements) {
     it.mapToMavenScope("runtime")
 }
-
-
 tasks.register('sourcesBundleJar', Jar) {
     it.archiveClassifier = 'sources'
     it.archiveBaseName = 'jst-cli-bundle'

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -22,8 +22,8 @@ java {
 }
 
 configurations {
-    shadow
-    shadow.extendsFrom(implementation)
+    include
+    include.extendsFrom(implementation)
 }
 
 dependencies {
@@ -31,9 +31,9 @@ dependencies {
     implementation "info.picocli:picocli:$picocli_version"
     implementation 'org.slf4j:slf4j-simple:2.0.13'
 
-    shadow project(":parchment")
-    shadow project(":accesstransformers")
-    shadow project(':interfaceinjection')
+    include project(":parchment")
+    include project(":accesstransformers")
+    include project(':interfaceinjection')
 
     testImplementation platform("org.junit:junit-bom:$junit_version")
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -45,7 +45,7 @@ test {
 }
 
 shadowJar {
-    configurations = [project.configurations.shadow]
+    configurations = [project.configurations.include]
     mergeServiceFiles()
 }
 
@@ -57,6 +57,26 @@ assemble.configure {
 components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
     skip()
 }
+
+abstract class ComponentMaker {
+    @Inject
+    abstract SoftwareComponentFactory getFactory();
+}
+
+def componentFactory = objects.newInstance(ComponentMaker).factory
+
+def shadowComponent = componentFactory.adhoc("shadow")
+project.components.add(shadowComponent)
+
+tasks.named('shadowJar', Jar) {
+    archiveClassifier = ''
+    archiveBaseName ='jst-cli-bundle'
+}
+
+shadowComponent.addVariantsFromConfiguration(configurations.shadowRuntimeElements) {
+    it.mapToMavenScope("runtime")
+}
+
 
 tasks.register('sourcesBundleJar', Jar) {
     it.archiveClassifier = 'sources'
@@ -86,7 +106,7 @@ publishing {
         create('bundle', MavenPublication) {
             artifactId = 'jst-cli-bundle'
 
-            project.shadow.component(bundle)
+            from components.shadow
             artifact(tasks.sourcesBundleJar)
             artifact(tasks.javadocBundleJar)
 


### PR DESCRIPTION
There are two current issues with the `jst-cli-bundle` publication that result in wacky metadata. First, the `shadow.component(...)` method is used to add the shadow jar to the publication -- this approach does not, in fact, use a component, but just manually adds the artifact, and adds dependencies to the pom. This probably helped hide the actual issue a bit -- the actual issue being that `shadowRuntimeElements.extendsFrom shadow` _within the shadow plugin itself_, as the shadow plugin uses the `shadow` configuration to mean "things you're _not_ bundling, and hence need to publish a dependency on". However, the jst-cli buildscript reuses this name for "things that _should_ be bundled" and so the jst-cli-bundle published a dependency on everything it bundled. This PR fixes this, and uses a component for publishing so we get gradle module metadata.