### PR TITLE
Synchronize stub creation

### DIFF
--- a/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/StubStore.java
+++ b/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/StubStore.java
@@ -60,7 +60,7 @@ class StubStore {
         return new InterfaceInformation(createStub(jvm, typeParameterCount), generics);
     }
 
-    private String createStub(String jvm, int typeParameterCount) {
+    private synchronized String createStub(String jvm, int typeParameterCount) {
         var fqn = jvmToFqn.get(jvm);
         if (fqn != null) return fqn;
 


### PR DESCRIPTION
Stubs could crash because of concurrent modification when JST runs in parallel and happens to inject an interface to 2 classes at the same time.  
The simplest and most intuitive solution is to synchronize the creation method as there are 3 maps involved, making CHM not the best option.