### PR TITLE
Allow folders as classpath entries

### DIFF
--- a/cli/src/main/java/net/neoforged/jst/cli/intellij/ClasspathSetup.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/intellij/ClasspathSetup.java
@@ -104,7 +104,8 @@ public final class ClasspathSetup {
         if (!Files.exists(libraryPath)) {
             throw new UncheckedIOException(new NoSuchFileException(libraryPath.toString()));
         }
-        ijEnv.addJarToClassPath(libraryPath);
+        if (Files.isDirectory(libraryPath)) ijEnv.addFolderToClasspath(libraryPath);
+        else ijEnv.addJarToClassPath(libraryPath);
         logger.debug("Added %s", libraryPath);
     }
 }

--- a/tests/data/accesstransformer/folder_classpath_entry/accesstransformer.cfg
+++ b/tests/data/accesstransformer/folder_classpath_entry/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public C1 get()La/b/c/Reference;

--- a/tests/data/accesstransformer/folder_classpath_entry/deps/a/b/c/Reference.java
+++ b/tests/data/accesstransformer/folder_classpath_entry/deps/a/b/c/Reference.java
@@ -1,0 +1,5 @@
+package a.b.c;
+
+public record Reference(int a) {
+
+}

--- a/tests/data/accesstransformer/folder_classpath_entry/expected/C1.java
+++ b/tests/data/accesstransformer/folder_classpath_entry/expected/C1.java
@@ -1,0 +1,7 @@
+import a.b.c.Reference;
+
+public class C1 {
+    public Reference get() {
+        return new Reference(1);
+    }
+}

--- a/tests/data/accesstransformer/folder_classpath_entry/source/C1.java
+++ b/tests/data/accesstransformer/folder_classpath_entry/source/C1.java
@@ -1,0 +1,7 @@
+import a.b.c.Reference;
+
+public class C1 {
+    private Reference get() {
+        return new Reference(1);
+    }
+}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -1,5 +1,6 @@
 package net.neoforged.jst.tests;
 
+import com.intellij.util.ArrayUtil;
 import net.neoforged.jst.cli.Main;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -286,6 +287,11 @@ public class EmbeddedTest {
         void testIllegal() throws Exception {
             runATTest("illegal");
         }
+
+        @Test
+        void testFolderClasspathEntries() throws Exception {
+            runATTest("folder_classpath_entry", "--classpath=" + testDataRoot.resolve("accesstransformer/folder_classpath_entry/deps"));
+        }
     }
 
     @Nested
@@ -350,10 +356,15 @@ public class EmbeddedTest {
         }
     }
 
-    protected final void runATTest(String testDirName) throws Exception {
+    protected final void runATTest(String testDirName, final String... extraArgs) throws Exception {
         testDirName = "accesstransformer/" + testDirName;
         var atPath = testDataRoot.resolve(testDirName).resolve("accesstransformer.cfg");
-        runTest(testDirName, txt -> txt.replace(atPath.toAbsolutePath().toString(), "{atpath}"), "--enable-accesstransformers", "--access-transformer", atPath.toString());
+        runTest(testDirName, txt -> txt.replace(atPath.toAbsolutePath().toString(), "{atpath}"), ArrayUtil.mergeArrays(
+            new String[]{
+                "--enable-accesstransformers", "--access-transformer", atPath.toString()
+            },
+            extraArgs
+        ));
     }
 
     protected final void runParchmentTest(String testDirName, String mappingsFilename) throws Exception {


### PR DESCRIPTION
The IJ parser allows for folders to be part of the classpath.
This behaviour is useful for supplying folders of compiled .class or
source files.
