### PR TITLE
Add an import helper and import interface-injected classes when possible

### DIFF
--- a/api/src/main/java/net/neoforged/jst/api/ImportHelper.java
+++ b/api/src/main/java/net/neoforged/jst/api/ImportHelper.java
@@ -1,0 +1,145 @@
+package net.neoforged.jst.api;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiImportStatementBase;
+import com.intellij.psi.PsiImportStaticStatement;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiPackage;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class used to import classes while processing a source file.
+ * @see ImportHelper#get(PsiFile)
+ */
+public class ImportHelper implements PostProcessReplacer {
+    private final PsiJavaFile psiFile;
+    private final Map<String, String> importedNames;
+
+    private final Set<String> successfulImports = new HashSet<>();
+
+    public ImportHelper(PsiJavaFile psiFile) {
+        this.psiFile = psiFile;
+
+        this.importedNames = new HashMap<>();
+
+        if (psiFile.getPackageStatement() != null) {
+            var resolved = psiFile.getPackageStatement().getPackageReference().resolve();
+            // We cannot import a class with the name of a class in the package of the file
+            if (resolved instanceof PsiPackage pkg) {
+                for (PsiClass cls : pkg.getClasses()) {
+                    importedNames.put(cls.getName(), cls.getQualifiedName());
+                }
+            }
+        }
+
+        if (psiFile.getImportList() != null) {
+            for (PsiImportStatementBase stmt : psiFile.getImportList().getImportStatements()) {
+                var res = stmt.resolve();
+                if (res instanceof PsiPackage pkg) {
+                    // Wildcard package imports will reserve all names of top-level classes in the package
+                    for (PsiClass cls : pkg.getClasses()) {
+                        importedNames.put(cls.getName(), cls.getQualifiedName());
+                    }
+                } else if (res instanceof PsiClass cls) {
+                    importedNames.put(cls.getName(), cls.getQualifiedName());
+                }
+            }
+
+            for (PsiImportStaticStatement stmt : psiFile.getImportList().getImportStaticStatements()) {
+                var res = stmt.resolve();
+                if (res instanceof PsiMethod method) {
+                    importedNames.put(method.getName(), method.getName());
+                } else if (res instanceof PsiField fld) {
+                    importedNames.put(fld.getName(), fld.getName());
+                } else if (res instanceof PsiClass cls && stmt.isOnDemand()) {
+                    // On-demand imports are static wildcard imports which will reserve the names of
+                    // - all static methods available through the imported class
+                    for (PsiMethod met : cls.getAllMethods()) {
+                        if (met.getModifierList().hasModifierProperty(PsiModifier.STATIC)) {
+                            importedNames.put(met.getName(), met.getName());
+                        }
+                    }
+
+                    // - all fields available through the imported class
+                    for (PsiField fld : cls.getAllFields()) {
+                        if (fld.getModifierList() != null && fld.getModifierList().hasModifierProperty(PsiModifier.STATIC)) {
+                            importedNames.put(fld.getName(), fld.getName());
+                        }
+                    }
+
+                    // - all inner classes available through the imported class directly
+                    for (PsiClass c : cls.getAllInnerClasses()) {
+                        importedNames.put(c.getName(), c.getQualifiedName());
+                    }
+
+                    // Note: to avoid possible issues, none of the above check for visibility. We prefer to be more conservative to make sure the output sources compile
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public boolean canImport(String name) {
+        return !importedNames.containsKey(name);
+    }
+
+    /**
+     * Attempts to import the given fully qualified class name, returning a reference to it which is either
+     * its short name (if an import is successful) or the qualified name if not.
+     */
+    public synchronized String importClass(String cls) {
+        var clsByDot = cls.split("\\.");
+        // We do not try to import classes in the default package or classes already imported
+        if (clsByDot.length == 1 || successfulImports.contains(cls)) return clsByDot[clsByDot.length - 1];
+        var name = clsByDot[clsByDot.length - 1];
+
+        if (Objects.equals(importedNames.get(name), cls)) {
+            return name;
+        }
+
+        if (canImport(name)) {
+            successfulImports.add(cls);
+            return name;
+        }
+
+        return cls;
+    }
+
+    @Override
+    public void process(Replacements replacements) {
+        if (successfulImports.isEmpty()) return;
+
+        var insertion = successfulImports.stream()
+                .sorted()
+                .map(s -> "import " + s + ";")
+                .collect(Collectors.joining("\n"));
+
+        if (psiFile.getImportList() != null && psiFile.getImportList().getLastChild() != null) {
+            var lastImport = psiFile.getImportList().getLastChild();
+            replacements.insertAfter(lastImport, "\n\n" + insertion);
+        } else {
+            replacements.insertBefore(psiFile.getClasses()[0], insertion + "\n\n");
+        }
+    }
+
+    @Nullable
+    public static ImportHelper get(PsiFile file) {
+        return file instanceof PsiJavaFile j ? get(j) : null;
+    }
+
+    public static ImportHelper get(PsiJavaFile file) {
+        return PostProcessReplacer.getOrCreateReplacer(file, ImportHelper.class, k -> new ImportHelper(file));
+    }
+}

--- a/api/src/main/java/net/neoforged/jst/api/PostProcessReplacer.java
+++ b/api/src/main/java/net/neoforged/jst/api/PostProcessReplacer.java
@@ -1,0 +1,38 @@
+package net.neoforged.jst.api;
+
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * A replacer linked to a {@link PsiFile} will run and collect replacements after all {@link SourceTransformer transformers} have processed the file.
+ */
+public interface PostProcessReplacer {
+    Key<Map<Class<?>, PostProcessReplacer>> REPLACERS = Key.create("jst.post_process_replacers");
+
+    /**
+     * Process replacements in the file after {@link SourceTransformer transformers} have processed it.
+     */
+    void process(Replacements replacements);
+
+    @UnmodifiableView
+    static Map<Class<?>, PostProcessReplacer> getReplacers(PsiFile file) {
+        var rep = file.getUserData(REPLACERS);
+        return rep == null ? Map.of() : Collections.unmodifiableMap(rep);
+    }
+
+    static <T extends PostProcessReplacer> T getOrCreateReplacer(PsiFile file, Class<T> type, Function<PsiFile, T> creator) {
+        var rep = file.getUserData(REPLACERS);
+        if (rep == null) {
+            rep = new ConcurrentHashMap<>();
+            file.putUserData(REPLACERS, rep);
+        }
+        //noinspection unchecked
+        return (T)rep.computeIfAbsent(type, k -> creator.apply(file));
+    }
+}

--- a/cli/src/main/java/net/neoforged/jst/cli/SourceFileProcessor.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/SourceFileProcessor.java
@@ -6,6 +6,7 @@ import net.neoforged.jst.api.FileEntry;
 import net.neoforged.jst.api.FileSink;
 import net.neoforged.jst.api.FileSource;
 import net.neoforged.jst.api.Logger;
+import net.neoforged.jst.api.PostProcessReplacer;
 import net.neoforged.jst.api.Replacement;
 import net.neoforged.jst.api.Replacements;
 import net.neoforged.jst.api.SourceTransformer;
@@ -151,6 +152,10 @@ class SourceFileProcessor implements AutoCloseable {
 
         for (var transformer : transformers) {
             transformer.visitFile(psiFile, replacements);
+        }
+
+        for (PostProcessReplacer rep : PostProcessReplacer.getReplacers(psiFile).values()) {
+            rep.process(replacements);
         }
 
         var readOnlyReplacements = Collections.unmodifiableList(replacementsList);

--- a/cli/src/test/java/net/neoforged/jst/cli/ImportHelperTest.java
+++ b/cli/src/test/java/net/neoforged/jst/cli/ImportHelperTest.java
@@ -1,0 +1,132 @@
+package net.neoforged.jst.cli;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiJavaFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import net.neoforged.jst.api.ImportHelper;
+import net.neoforged.jst.api.Logger;
+import net.neoforged.jst.api.Replacements;
+import net.neoforged.jst.cli.intellij.IntelliJEnvironmentImpl;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ImportHelperTest {
+    static IntelliJEnvironmentImpl ijEnv;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        ijEnv = new IntelliJEnvironmentImpl(new Logger(null, null));
+        ijEnv.addCurrentJdkToClassPath();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        ijEnv.close();
+    }
+
+    @Test
+    public void testSimpleImports() {
+        var helper = getImportHelper("""
+import java.util.Collection;
+import java.lang.annotation.Retention;
+import java.util.concurrent.atomic.AtomicReference;""");
+
+        assertFalse(helper.canImport("Collection"), "Collection can wrongly be imported");
+        assertFalse(helper.canImport("Retention"), "Retention can wrongly be imported");
+        assertFalse(helper.canImport("AtomicReference"), "AtomicReference can wrongly be imported");
+
+        assertTrue(helper.canImport("MyRandomClass"), "Cannot import a non-reserved name");
+    }
+
+    @Test
+    public void testWildcardImports() {
+        var helper = getImportHelper("""
+import java.util.concurrent.*;""");
+
+        assertFalse(helper.canImport("Future"), "Future can wrongly be imported");
+        assertFalse(helper.canImport("Executor"), "Executor can wrongly be imported");
+
+        assertTrue(helper.canImport("ThisWillNotExist"), "Cannot import a non-reserved name");
+    }
+
+    @Test
+    public void testStaticImports() {
+        var helper = getImportHelper("""
+import static java.util.Spliterators.emptyDoubleSpliterator;
+import static java.util.Collections.*;""");
+
+        assertFalse(helper.canImport("emptyDoubleSpliterator"), "emptyDoubleSpliterator can wrongly be imported");
+
+        assertFalse(helper.canImport("min"), "min can wrongly be imported");
+        assertFalse(helper.canImport("checkedSortedMap"), "checkedSortedMap can wrongly be imported");
+        assertFalse(helper.canImport("EMPTY_LIST"), "EMPTY_LIST can wrongly be imported");
+
+        assertTrue(helper.canImport("ThisWillNotExist"), "Cannot import a non-reserved name");
+    }
+
+    @Test
+    void testReplace() {
+        var file = parseSingleFile("""
+package java.lang.annotation;
+
+import java.util.*;
+
+class MyClass {
+}""");
+
+        var helper = ImportHelper.get(file);
+
+        assertEquals("HelloWorld", helper.importClass("com.hello.world.HelloWorld"));
+
+        assertEquals("Annotation", helper.importClass("java.lang.annotation.Annotation"));
+        assertEquals("com.hello.world.Annotation", helper.importClass("com.hello.world.Annotation"));
+
+        assertEquals("List", helper.importClass("java.util.List"));
+        assertEquals("com.hello.world.List", helper.importClass("com.hello.world.List"));
+
+        assertEquals("Thing", helper.importClass("a.b.c.Thing"));
+
+        var rep = new Replacements();
+        helper.process(rep);
+
+        assertThat(rep.apply(file.getText()))
+                .isEqualToNormalizingNewlines("""
+                        package java.lang.annotation;
+                                                
+                        import java.util.*;
+                        import a.b.c.Thing;
+                        import com.hello.world.HelloWorld;
+                                                
+                        class MyClass {
+                        }""");
+    }
+
+    private ImportHelper getImportHelper(@Language("JAVA") String javaCode) {
+        var file = parseSingleFile(javaCode);
+        return new ImportHelper(file);
+    }
+
+    private PsiJavaFile parseSingleFile(@Language("JAVA") String javaCode) {
+        return parseSingleElement(javaCode, PsiJavaFile.class);
+    }
+
+    private <T extends PsiElement> T parseSingleElement(@Language("JAVA") String javaCode, Class<T> type) {
+        var file = ijEnv.parseFileFromMemory("Test.java", javaCode);
+
+        var elements = PsiTreeUtil.collectElementsOfType(file, type);
+        assertEquals(1, elements.size());
+        return elements.iterator().next();
+    }
+}

--- a/tests/data/interfaceinjection/additive_injection/expected/net/Example.java
+++ b/tests/data/interfaceinjection/additive_injection/expected/net/Example.java
@@ -1,4 +1,6 @@
 package net;
 
-public class Example implements Runnable, com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public class Example implements Runnable, InjectedInterface {
 }

--- a/tests/data/interfaceinjection/additive_injection/expected/net/Example2.java
+++ b/tests/data/interfaceinjection/additive_injection/expected/net/Example2.java
@@ -2,5 +2,7 @@ package net;
 
 import java.util.*;
 
-public class Example2 implements Runnable, Consumer<?>, com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public class Example2 implements Runnable, Consumer<?>, InjectedInterface {
 }

--- a/tests/data/interfaceinjection/generics/expected/com/MyTarget.java
+++ b/tests/data/interfaceinjection/generics/expected/com/MyTarget.java
@@ -1,4 +1,6 @@
 package com;
 
-public class MyTarget<T> implements com.InjectedGeneric<T, MyTarget<T>> {
+import com.InjectedGeneric;
+
+public class MyTarget<T> implements InjectedGeneric<T, MyTarget<T>> {
 }

--- a/tests/data/interfaceinjection/injected_marker/expected/SomeClass.java
+++ b/tests/data/interfaceinjection/injected_marker/expected/SomeClass.java
@@ -1,2 +1,5 @@
-public class SomeClass implements @com.markers.InjectedMarker com.example.InjectedInterface {
+import com.example.InjectedInterface;
+import com.markers.InjectedMarker;
+
+public class SomeClass implements @InjectedMarker InjectedInterface {
 }

--- a/tests/data/interfaceinjection/inner_stubs/expected/ExampleClass.java
+++ b/tests/data/interfaceinjection/inner_stubs/expected/ExampleClass.java
@@ -1,2 +1,5 @@
-public class ExampleClass implements com.example.InjectedInterface.Inner, com.example.InjectedInterface.Inner.SubInner {
+import com.example.InjectedInterface.Inner;
+import com.example.InjectedInterface.Inner.SubInner;
+
+public class ExampleClass implements Inner, SubInner {
 }

--- a/tests/data/interfaceinjection/interface_target/expected/com/example/ExampleInterface.java
+++ b/tests/data/interfaceinjection/interface_target/expected/com/example/ExampleInterface.java
@@ -1,4 +1,6 @@
 package com.example;
 
-public interface ExampleInterface extends com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public interface ExampleInterface extends InjectedInterface {
 }

--- a/tests/data/interfaceinjection/interface_target/expected/com/example/ExampleInterfaceAdditive.java
+++ b/tests/data/interfaceinjection/interface_target/expected/com/example/ExampleInterfaceAdditive.java
@@ -1,4 +1,6 @@
 package com.example;
 
-public interface ExampleInterfaceAdditive extends Runnable, com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public interface ExampleInterfaceAdditive extends Runnable, InjectedInterface {
 }

--- a/tests/data/interfaceinjection/multiple_interfaces/expected/MyTarget.java
+++ b/tests/data/interfaceinjection/multiple_interfaces/expected/MyTarget.java
@@ -1,2 +1,5 @@
-public class MyTarget implements com.example.I1, com.example.I2 {
+import com.example.I1;
+import com.example.I2;
+
+public class MyTarget implements I1, I2 {
 }

--- a/tests/data/interfaceinjection/simple_injection/expected/net/me/Example.java
+++ b/tests/data/interfaceinjection/simple_injection/expected/net/me/Example.java
@@ -1,4 +1,6 @@
 package net.me;
 
-public class Example implements com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public class Example implements InjectedInterface {
 }

--- a/tests/data/interfaceinjection/simple_injection/expected/net/me/Example2.java
+++ b/tests/data/interfaceinjection/simple_injection/expected/net/me/Example2.java
@@ -1,4 +1,6 @@
 package net.me;
 
-public class Example2 extends Object implements com.example.InjectedInterface {
+import com.example.InjectedInterface;
+
+public class Example2 extends Object implements InjectedInterface {
 }

--- a/tests/data/interfaceinjection/stubs/expected/ExampleClass.java
+++ b/tests/data/interfaceinjection/stubs/expected/ExampleClass.java
@@ -1,2 +1,5 @@
-public class ExampleClass implements InjectedRootInterface, com.example.II2, com.example.InjectedInterface {
+import com.example.II2;
+import com.example.InjectedInterface;
+
+public class ExampleClass implements II2, InjectedInterface, InjectedRootInterface {
 }


### PR DESCRIPTION
This PR adds an `ImportHelper` used to import classes inside the file when possible, to increase readability. This helper is API that can be used by plugins and is implemented as a `PostProcessReplacer`. This is a new API that can attach replacers that run after transformers have processed a file using a user-data backed map.

Interface injection is also switched to use the `ImportHelper` and import interface-injected classes when possible.