### PR TITLE
Catch conflicts when multiple parameters in the same scope get renamed to the same name

### DIFF
--- a/tests/data/parchment/conflicts/expected/com/example/Example.java
+++ b/tests/data/parchment/conflicts/expected/com/example/Example.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public class Example {
+    public void m(String in, String p_in) {
+        class Nested {
+            public void m(String p_p_in, String out) {
+
+            }
+        }
+    }
+}

--- a/tests/data/parchment/conflicts/mappings.tsrg
+++ b/tests/data/parchment/conflicts/mappings.tsrg
@@ -1,0 +1,9 @@
+tsrg2 left right
+obfuscated_c com/example/Example
+	obfuscated_m (Ljava/lang/String;)V m
+		0 o in
+		1 o in
+obfuscated_c$nested com/example/Example$1Nested
+	obfuscated_m (Ljava/lang/String;)V m
+		0 o in
+		1 o out

--- a/tests/data/parchment/conflicts/source/com/example/Example.java
+++ b/tests/data/parchment/conflicts/source/com/example/Example.java
@@ -1,0 +1,11 @@
+package com.example;
+
+public class Example {
+    public void m(String a1, String ac2) {
+        class Nested {
+            public void m(String ac3, String a4) {
+
+            }
+        }
+    }
+}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -224,6 +224,11 @@ public class EmbeddedTest {
         void testAnonymousClasses() throws Exception {
             runParchmentTest("anonymous_classes", "mappings.tsrg");
         }
+
+        @Test
+        void testConflicts() throws Exception {
+            runParchmentTest("conflicts", "mappings.tsrg", "--parchment-conflict-prefix=p_");
+        }
     }
 
     @Nested
@@ -367,9 +372,11 @@ public class EmbeddedTest {
         ));
     }
 
-    protected final void runParchmentTest(String testDirName, String mappingsFilename) throws Exception {
+    protected final void runParchmentTest(String testDirName, String mappingsFilename, String... extraArgs) throws Exception {
         testDirName = "parchment/" + testDirName;
-        runTest(testDirName, UnaryOperator.identity(), "--enable-parchment", "--parchment-mappings", testDataRoot.resolve(testDirName).resolve(mappingsFilename).toString());
+        var args = new ArrayList<>(Arrays.asList("--enable-parchment", "--parchment-mappings", testDataRoot.resolve(testDirName).resolve(mappingsFilename).toString()));
+        args.addAll(Arrays.asList(extraArgs));
+        runTest(testDirName, UnaryOperator.identity(), args.toArray(String[]::new));
     }
 
     protected final void runTest(String testDirName, UnaryOperator<String> consoleMapper, String... args) throws Exception {


### PR DESCRIPTION
The previous conflict checking did not check for parameters in the same scope being renamed to the same name which could lead to ambiguous references after JST is applied and in turn behavioural differences.
Fixes #44 