### PR TITLE
Generate stubs for generic arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The interfaces can have generic parameter declarations. Assuming the target clas
 we could implement `Supplier<T>` using `java/util/function/Supplier<T>`.
 
 > [!NOTE]  
-> Generics are *copied verbatim*. If you need the generics to reference a class, please use its fully qualified name (e.g. `java/util/function/Supplier<java.util.concurrent.atomic.AtomicInteger>`).
+> Generics are *copied verbatim*. If you need the generics to reference a class, please use its fully qualified name (e.g. `java/util/function/Supplier<java.util.concurrent.atomic.AtomicInteger>`). As an exception to this rule, inner classes should be separated by `$` (e.g. `java/util/function/Supplier<java.util.Map$Entry>`).
 
 ### Custom transformers
 Third parties can use JST to implement their source file own transformations.  

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected/com/MyTarget.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected/com/MyTarget.java
@@ -1,0 +1,7 @@
+package com;
+
+import com.CustomInterface;
+import com.InjectedInterface;
+
+public class MyTarget<T> implements CustomInterface<com.example.TypeParameter.InnerClass>, InjectedInterface<java.util.Map.Entry<? extends com.example.WeirdSupplier<T>, com.example.Classes.Generics<T, java.lang.Integer, com.example.WeirdSupplier<?>>>> {
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/CustomInterface.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/CustomInterface.java
@@ -1,0 +1,4 @@
+package com;
+
+public interface CustomInterface<A> {
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/InjectedInterface.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/InjectedInterface.java
@@ -1,0 +1,4 @@
+package com;
+
+public interface InjectedInterface<A> {
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/Classes.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/Classes.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public interface Classes {
+    public interface Generics<A, B, C> {
+    }
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/TypeParameter.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/TypeParameter.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public interface TypeParameter {
+    public interface InnerClass {
+    }
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/WeirdSupplier.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/expected_stub/com/example/WeirdSupplier.java
@@ -1,0 +1,4 @@
+package com.example;
+
+public interface WeirdSupplier<A> {
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/injectedinterfaces.json
+++ b/tests/data/interfaceinjection/nested_generic_stubs/injectedinterfaces.json
@@ -1,0 +1,6 @@
+{
+  "com/MyTarget": [
+    "com/InjectedInterface<java.util.Map$Entry<? extends com.example.WeirdSupplier<T>, com.example.Classes$Generics<T, java.lang.Integer, com.example.WeirdSupplier<?>>>>",
+    "com/CustomInterface<com.example.TypeParameter$InnerClass>"
+  ]
+}

--- a/tests/data/interfaceinjection/nested_generic_stubs/source/com/MyTarget.java
+++ b/tests/data/interfaceinjection/nested_generic_stubs/source/com/MyTarget.java
@@ -1,0 +1,4 @@
+package com;
+
+public class MyTarget<T> {
+}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -350,6 +350,11 @@ public class EmbeddedTest {
         void testGenerics() throws Exception {
             runInterfaceInjectionTest("generics", tempDir);
         }
+
+        @Test
+        void testNestedGenericStubs() throws Exception {
+            runInterfaceInjectionTest("nested_generic_stubs", tempDir);
+        }
     }
 
     protected final void runInterfaceInjectionTest(String testDirName, Path tempDir, String... additionalArgs) throws Exception {


### PR DESCRIPTION
Until now, generic arguments wouldn't have stubs generated, meaning that you could not inject an interface with a type parameter that references your own classes. This fixes that. For this to be fixed, an exception from the "verbatim copy" rule had to be added: inner classes must use $. This change does not however break any existing *working* builds.