### PR TITLE
Ensure parent directories are created before writing files in FolderFileSink

### DIFF
--- a/cli/src/main/java/net/neoforged/jst/cli/io/FolderFileSink.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/io/FolderFileSink.java
@@ -18,7 +18,7 @@ record FolderFileSink(Path path) implements FileSink {
     public void putFile(String relativePath, FileTime lastModified, byte[] content) throws IOException {
         var targetPath = path.resolve(relativePath);
 
-        if (!Files.isDirectory(targetPath.getParent()))
+        if (targetPath.getParent() != null && !Files.isDirectory(targetPath.getParent()))
             Files.createDirectories(targetPath.getParent());
 
         Files.write(targetPath, content);

--- a/cli/src/main/java/net/neoforged/jst/cli/io/FolderFileSink.java
+++ b/cli/src/main/java/net/neoforged/jst/cli/io/FolderFileSink.java
@@ -17,6 +17,10 @@ record FolderFileSink(Path path) implements FileSink {
     @Override
     public void putFile(String relativePath, FileTime lastModified, byte[] content) throws IOException {
         var targetPath = path.resolve(relativePath);
+
+        if (!Files.isDirectory(targetPath.getParent()))
+            Files.createDirectories(targetPath.getParent());
+
         Files.write(targetPath, content);
         Files.setLastModifiedTime(targetPath, lastModified);
     }


### PR DESCRIPTION
When a folder sink is used it only creates the root directory, but not any intermediary directories of files.

An example when this crash occurs is when a Zip is used as input format, while a folder is output.

Because the zip does not have directory entries it will not trigger putDirectory properly, causing a crash when it processes the first file in a directory (generally META-INF/METADATA.MF).