### PR TITLE
feat: Add a only javadoc application mode to the parchment plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Usage: jst [-hV] [--debug] [--in-format=<inputFormat>] [--libraries-list=<librar
            [--problems-report=<problemsReport>] [--classpath=<addToClasspath>]...
            [--ignore-prefix=<ignoredPrefixes>]... [--enable-parchment
            --parchment-mappings=<mappingsPath> [--[no-]parchment-javadoc]
-           [--parchment-conflict-prefix=<conflictPrefix>]] [--enable-accesstransformers
-           --access-transformer=<atFiles> [--access-transformer=<atFiles>]...
+           [--only-parchment-javadoc] [--parchment-conflict-prefix=<conflictPrefix>]]
+           [--enable-accesstransformers --access-transformer=<atFiles> [--access-transformer=<atFiles>]...
            [--access-transformer-validation=<validation>]] [--enable-interface-injection
            [--interface-injection-stubs=<stubOut>]
            [--interface-injection-marker=<annotationMarker>]
@@ -102,6 +102,9 @@ Plugin - parchment
                              existing variable names
       --[no-]parchment-javadoc
                            Whether Parchment javadocs should be applied
+      --only-parchment-javadoc
+                           Whether to only apply Parchment javadocs, skipping parameter renaming.
+                             Overrides the --[no-]parchment-javadocs setting
       --parchment-mappings=<mappingsPath>
                            The location of the Parchment mappings file
 Plugin - accesstransformers

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Plugin - parchment
                            Whether Parchment javadocs should be applied
       --only-parchment-javadoc
                            Whether to only apply Parchment javadocs, skipping parameter renaming.
-                             Overrides the --[no-]parchment-javadocs setting
+                             Overrides the --[no-]parchment-javadoc setting
       --parchment-mappings=<mappingsPath>
                            The location of the Parchment mappings file
 Plugin - accesstransformers

--- a/parchment/src/main/java/net/neoforged/jst/parchment/ParchmentTransformer.java
+++ b/parchment/src/main/java/net/neoforged/jst/parchment/ParchmentTransformer.java
@@ -26,7 +26,7 @@ public class ParchmentTransformer implements SourceTransformer {
     )
     public boolean enableJavadoc = true;
 
-    @CommandLine.Option(names = "--only-parchment-javadoc", description = "Whether to only apply Parchment javadocs, skipping parameter renaming. Overrides the --[no-]parchment-javadocs setting")
+    @CommandLine.Option(names = "--only-parchment-javadoc", description = "Whether to only apply Parchment javadocs, skipping parameter renaming. Overrides the --[no-]parchment-javadoc setting")
     public boolean onlyJavadoc = false;
 
     @CommandLine.Option(names = "--parchment-conflict-prefix", description = "Apply the prefix specified if a Parchment parameter name conflicts with existing variable names")

--- a/parchment/src/main/java/net/neoforged/jst/parchment/ParchmentTransformer.java
+++ b/parchment/src/main/java/net/neoforged/jst/parchment/ParchmentTransformer.java
@@ -26,6 +26,9 @@ public class ParchmentTransformer implements SourceTransformer {
     )
     public boolean enableJavadoc = true;
 
+    @CommandLine.Option(names = "--only-parchment-javadoc", description = "Whether to only apply Parchment javadocs, skipping parameter renaming. Overrides the --[no-]parchment-javadocs setting")
+    public boolean onlyJavadoc = false;
+
     @CommandLine.Option(names = "--parchment-conflict-prefix", description = "Apply the prefix specified if a Parchment parameter name conflicts with existing variable names")
     public String conflictPrefix;
 
@@ -56,7 +59,7 @@ public class ParchmentTransformer implements SourceTransformer {
 
     @Override
     public void visitFile(PsiFile psiFile, Replacements replacements) {
-        var visitor = new GatherReplacementsVisitor(namesAndDocs, enableJavadoc, conflictResolver, replacements);
+        var visitor = new GatherReplacementsVisitor(namesAndDocs, enableJavadoc, onlyJavadoc, conflictResolver, replacements);
         visitor.visitElement(psiFile);
     }
 


### PR DESCRIPTION
This pull request adds a new CLI option, `--only-parchment-javadoc`, which when set, overrides the `--[no-]-parchment-javadoc` setting and skips the parameter renaming step while recording replacements for `@param` names in the javadocs, based on the source and finally applying the JDs to the source. The replacement step is there for correct `@param` names.
It is useful for projects that use their own tooling for param names but still want to benefit from the javadocs specified in Parchment, which this feature allows them to do. 🎉
The idea behind this was brought up in discord some time ago in the #tooling-dev channel 