### PR TITLE
Fix interface injection deduplication when all injected interfaces are already present

### DIFF
--- a/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/InjectInterfacesVisitor.java
+++ b/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/InjectInterfacesVisitor.java
@@ -79,6 +79,10 @@ class InjectInterfacesVisitor extends PsiRecursiveElementVisitor {
                 .sorted(Comparator.naturalOrder())
                 .collect(Collectors.joining(", "));
 
+        if (interfaceImplementation.isEmpty()) {
+            return; // Nothing to do, all injected interfaces are already present
+        }
+
         if (implementsList.getChildren().length == 0) {
             StringBuilder text = new StringBuilder();
 

--- a/tests/data/interfaceinjection/deduplication/expected/pkg/Example.java
+++ b/tests/data/interfaceinjection/deduplication/expected/pkg/Example.java
@@ -1,0 +1,6 @@
+package pkg;
+
+import java.util.Set;
+
+public class Example implements Set {
+}

--- a/tests/data/interfaceinjection/deduplication/injectedinterfaces.json
+++ b/tests/data/interfaceinjection/deduplication/injectedinterfaces.json
@@ -1,0 +1,3 @@
+{
+  "pkg/Example": "java/util/Set"
+}

--- a/tests/data/interfaceinjection/deduplication/source/pkg/Example.java
+++ b/tests/data/interfaceinjection/deduplication/source/pkg/Example.java
@@ -1,0 +1,6 @@
+package pkg;
+
+import java.util.Set;
+
+public class Example implements Set {
+}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -317,6 +317,11 @@ public class EmbeddedTest {
         }
 
         @Test
+        void testDeduplication() throws Exception {
+            runInterfaceInjectionTest("deduplication", tempDir);
+        }
+
+        @Test
         void testAdditiveInjection() throws Exception {
             runInterfaceInjectionTest("additive_injection", tempDir);
         }


### PR DESCRIPTION
Fixes a spurious `, ` after the implements list when all injected interfaces on a class have been removed through deduplication because they were already present.

Example:

A class already implements `java.util.Set`. Trying to inject `java.util.Set` leads to `class C implements Set, {`