### PR TITLE
Fix interfaces being injected after permits clause

### DIFF
--- a/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/InjectInterfacesVisitor.java
+++ b/interfaceinjection/src/main/java/net/neoforged/jst/interfaceinjection/InjectInterfacesVisitor.java
@@ -86,16 +86,20 @@ class InjectInterfacesVisitor extends PsiRecursiveElementVisitor {
         if (implementsList.getChildren().length == 0) {
             StringBuilder text = new StringBuilder();
 
+            // The clause order is extends/implements first, then permits. So if the class does not have an implements clause
+            // but it has a permits clause, we must ensure we insert the implements clause before the permits clause
+            PsiElement nextClause = psiClass.getPermitsList() == null ? psiClass.getLBrace() : psiClass.getPermitsList();
+
             // `public class Cls{}` is valid, but we cannot inject the implements exactly next to the class name, so we need
             // to make sure that we have spacing
-            if (!(psiClass.getLBrace().getPrevSibling() instanceof PsiWhiteSpace)) {
+            if (!(nextClause.getPrevSibling() instanceof PsiWhiteSpace)) {
                 text.append(' ');
             }
             text.append(psiClass.isInterface() ? "extends" : "implements").append(' ');
             text.append(interfaceImplementation);
             text.append(' ');
 
-            replacements.insertBefore(psiClass.getLBrace(), text.toString());
+            replacements.insertBefore(nextClause, text.toString());
         } else {
             replacements.insertAfter(implementsList.getLastChild(), ", " + interfaceImplementation);
         }

--- a/tests/data/interfaceinjection/clause_order/expected/com/example/Example.java
+++ b/tests/data/interfaceinjection/clause_order/expected/com/example/Example.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.example.InjectedInterface;
+
+class Example implements InjectedInterface permits Permitted {
+
+}
+
+final class Permitted extends Example {}

--- a/tests/data/interfaceinjection/clause_order/injectedinterfaces.json
+++ b/tests/data/interfaceinjection/clause_order/injectedinterfaces.json
@@ -1,0 +1,3 @@
+{
+  "com/example/Example": "com/example/InjectedInterface"
+}

--- a/tests/data/interfaceinjection/clause_order/source/com/example/Example.java
+++ b/tests/data/interfaceinjection/clause_order/source/com/example/Example.java
@@ -1,0 +1,7 @@
+package com.example;
+
+class Example permits Permitted {
+
+}
+
+final class Permitted extends Example {}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -331,6 +331,11 @@ public class EmbeddedTest {
         }
 
         @Test
+        void testClauseOrder() throws Exception {
+            runInterfaceInjectionTest("clause_order", tempDir);
+        }
+
+        @Test
         void testInterfaceTarget() throws Exception {
             runInterfaceInjectionTest("interface_target", tempDir);
         }


### PR DESCRIPTION
The clause order is extends/implements first, then permits. So if the class does not have an implements clause but it has a permits clause, we must ensure we insert the implements clause before the permits clause