### PR TITLE
Prevent importing classes with the same name as any classes in the file

### DIFF
--- a/api/src/main/java/net/neoforged/jst/api/ImportHelper.java
+++ b/api/src/main/java/net/neoforged/jst/api/ImportHelper.java
@@ -86,6 +86,18 @@ public class ImportHelper implements PostProcessReplacer {
                 }
             }
         }
+
+        // To avoid any ambiguity, we cannot import a class with the same name as any of the classes in the file
+        for (PsiClass topLevelClass : psiFile.getClasses()) {
+            markClassNamesAsUsed(topLevelClass);
+        }
+    }
+
+    private void markClassNamesAsUsed(PsiClass topLevelClass) {
+        importedNames.put(topLevelClass.getName(), topLevelClass.getQualifiedName());
+        for (PsiClass inner : topLevelClass.getAllInnerClasses()) {
+            markClassNamesAsUsed(inner);
+        }
     }
 
     @VisibleForTesting

--- a/cli/src/test/java/net/neoforged/jst/cli/ImportHelperTest.java
+++ b/cli/src/test/java/net/neoforged/jst/cli/ImportHelperTest.java
@@ -111,6 +111,26 @@ class MyClass {
                         }""");
     }
 
+    @Test
+    void testCannotImportNamesInFile() {
+        var helper = getImportHelper("""
+package com.test;
+
+class MyClass {
+    interface InnerClass {
+        interface SubInner {
+            
+        }
+    }
+}""");
+
+        assertFalse(helper.canImport("MyClass"));
+        assertFalse(helper.canImport("InnerClass"));
+        assertFalse(helper.canImport("SubInner"));
+
+        assertTrue(helper.canImport("UnrelatedClassName"));
+    }
+
     private ImportHelper getImportHelper(@Language("JAVA") String javaCode) {
         var file = parseSingleFile(javaCode);
         return new ImportHelper(file);


### PR DESCRIPTION
Avoids the possibility of an interface injection such as the one below causing a recursive class declaration
```json
"com/mojang/blaze3d/pipeline/RenderPipeline$Snippet": [
    "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderPipeline$Snippet"
  ],
  "com/mojang/blaze3d/pipeline/RenderPipeline$Builder": [
    "net/fabricmc/fabric/api/client/rendering/v1/FabricRenderPipeline$Builder"
  ],
```